### PR TITLE
Adds support for floating cursor

### DIFF
--- a/pkg/volume/azure_dd/azure_dd.go
+++ b/pkg/volume/azure_dd/azure_dd.go
@@ -187,7 +187,7 @@ func getMaxDataDiskCount(instanceType string, sizeList *[]compute.VirtualMachine
 			continue
 		}
 		if strings.ToUpper(*size.Name) == vmsize {
-			klog.V(2).Infof("got a matching size in getMaxDataDiskCount, Name: %s, MaxDataDiskCount: %d", *size.Name, *size.MaxDataDiskCount)
+			klog.V(12).Infof("got a matching size in getMaxDataDiskCount, Name: %s, MaxDataDiskCount: %d", *size.Name, *size.MaxDataDiskCount)
 			return int64(*size.MaxDataDiskCount)
 		}
 	}

--- a/staging/src/k8s.io/client-go/testing/fixture.go
+++ b/staging/src/k8s.io/client-go/testing/fixture.go
@@ -339,8 +339,10 @@ func (t *tracker) getWatches(gvr schema.GroupVersionResource, ns string) []*watc
 		if w := t.watchers[gvr][ns]; w != nil {
 			watches = append(watches, w...)
 		}
-		if w := t.watchers[gvr][""]; w != nil {
-			watches = append(watches, w...)
+		if ns != metav1.NamespaceAll {
+			if w := t.watchers[gvr][metav1.NamespaceAll]; w != nil {
+				watches = append(watches, w...)
+			}
 		}
 	}
 	return watches

--- a/staging/src/k8s.io/client-go/testing/fixture_test.go
+++ b/staging/src/k8s.io/client-go/testing/fixture_test.go
@@ -131,26 +131,47 @@ func TestWatchCallMultipleInvocation(t *testing.T) {
 	cases := []struct {
 		name string
 		op   watch.EventType
+		ns   string
 	}{
 		{
 			"foo",
 			watch.Added,
+			"test_namespace",
 		},
 		{
 			"bar",
 			watch.Added,
+			"test_namespace",
+		},
+		{
+			"baz",
+			watch.Added,
+			"",
 		},
 		{
 			"bar",
 			watch.Modified,
+			"test_namespace",
+		},
+		{
+			"baz",
+			watch.Modified,
+			"",
 		},
 		{
 			"foo",
 			watch.Deleted,
+			"test_namespace",
 		},
 		{
 			"bar",
 			watch.Deleted,
+			"test_namespace",
+		},
+		{
+			"baz",
+			watch.Deleted,
+			"",
 		},
 	}
 
@@ -169,6 +190,7 @@ func TestWatchCallMultipleInvocation(t *testing.T) {
 	wg.Add(len(watchNamespaces))
 	for idx, watchNamespace := range watchNamespaces {
 		i := idx
+		watchNamespace := watchNamespace
 		w, err := o.Watch(testResource, watchNamespace)
 		if err != nil {
 			t.Fatalf("test resource watch failed in %s: %v", watchNamespace, err)
@@ -176,14 +198,17 @@ func TestWatchCallMultipleInvocation(t *testing.T) {
 		go func() {
 			assert.NoError(t, err, "watch invocation failed")
 			for _, c := range cases {
-				fmt.Printf("%#v %#v\n", c, i)
-				event := <-w.ResultChan()
-				accessor, err := meta.Accessor(event.Object)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
+				if watchNamespace == "" || c.ns == watchNamespace {
+					fmt.Printf("%#v %#v\n", c, i)
+					event := <-w.ResultChan()
+					accessor, err := meta.Accessor(event.Object)
+					if err != nil {
+						t.Fatalf("unexpected error: %v", err)
+					}
+					assert.Equal(t, c.op, event.Type, "watch event mismatched")
+					assert.Equal(t, c.name, accessor.GetName(), "watched object mismatch")
+					assert.Equal(t, c.ns, accessor.GetNamespace(), "watched object mismatch")
 				}
-				assert.Equal(t, c.op, event.Type, "watch event mismatched")
-				assert.Equal(t, c.name, accessor.GetName(), "watched object mismatch")
 			}
 			wg.Done()
 		}()
@@ -191,13 +216,13 @@ func TestWatchCallMultipleInvocation(t *testing.T) {
 	for _, c := range cases {
 		switch c.op {
 		case watch.Added:
-			obj := getArbitraryResource(testResource, c.name, "test_namespace")
-			o.Create(testResource, obj, "test_namespace")
+			obj := getArbitraryResource(testResource, c.name, c.ns)
+			o.Create(testResource, obj, c.ns)
 		case watch.Modified:
-			obj := getArbitraryResource(testResource, c.name, "test_namespace")
-			o.Update(testResource, obj, "test_namespace")
+			obj := getArbitraryResource(testResource, c.name, c.ns)
+			o.Update(testResource, obj, c.ns)
 		case watch.Deleted:
-			o.Delete(testResource, "test_namespace", c.name)
+			o.Delete(testResource, c.ns, c.name)
 		}
 	}
 	wg.Wait()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
